### PR TITLE
ProtGraph Fixes and more (v0.1.1)

### DIFF
--- a/.github/workflows/super_linter.yaml
+++ b/.github/workflows/super_linter.yaml
@@ -14,5 +14,6 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_MYPY: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FT                   /note="O -> L (in Example)"
 FT                   /evidence="EXAMPLE Variant 2"
 FT                   /id="VAR_XXXXX2"
 FT   VARIANT         5
-FT                   /note="L -> K (in Example)"
+FT                   /note="T -> K (in Example)"
 FT                   /evidence="EXAMPLE Variant 3"
 FT                   /id="VAR_XXXXX3"
 SQ   SEQUENCE   8 AA;  988 MW;  XXXXXXXXXXXXXXXX CRC64;
@@ -57,17 +57,17 @@ By combining multiple flags, it is possible to retrieve the number of  peptides 
 |----------------|---|---|---|---|---|---|---|---|
 | #Peptides      | 3 | 5 | 8 | 8 | 6 | 4 | 8 | 4 |
 
-
 Dividing this table by `46` would give us the distribution of the peptide lengths for the given protein.
 
-
-
 ## Setting up ProtGraph
+
 You can download Protgraph directly from [pypi](https://pypi.org/project/protgraph).
 
 Simply execute: `pip install protgraph`  or `pip install --user protgraph`
 
-### Installing via pip from source (for usage)
+It is also avialable in [bioconda](https://bioconda.github.io/). The installation instruction can be found here: [protgraph](https://anaconda.org/bioconda/protgraph)
+
+### Installing via pip from source (for usage and development)
 
 First clone this project and enter its directory via:
 
@@ -76,27 +76,22 @@ git clone git@github.com:mpc-bioinformatics/ProtGraph.git
 cd ProtGraph/
 ```
 
-Depending on how you want to use this project follow either the usage instructions for only using Protgraph or the development and tests instructions if you want to use it in a python project or even develop something in ProtGraph itself.
+Depending on how you want to use this project follow either the usage instructions or the development and tests instructions.
 
-If you only want to use ProtGraph from the command line, it is sufficient to simply execute: `pip install --user .`
+#### Installing for Usage
+
+If you only want to use ProtGraph from the command line, it is sufficient to simply execute: `pip install --user .`. Alternatively you can execute `python setup.py install`.
 
 The "binary" `protgraph` should be available in your command line after it finished. You can now convert UniProt-entries into graphs!
 
-#### Troubleshooting
-
-ProtGraph has many dependencies which are mostly due to the export functionalities. For the dependency `psycopg2`, it may be neccessary to install PostgreSQL on your operating system, so that the wheel can be built. It should be sufficient to install it as follows `sudo pacman -S postgres` (adapt this for `apt` and alike).
-
-If the command `protgraph` cannot be found, make sure that you have included the python executables folder in your environment variable `PATH`. (If pip was executed with the flag `--user`, then the binaries should be available in the folder: `~/.local/bin`)
-
-### Installing via pipenv and pyenv (for development and tests)
+#### Installing for Development and Test
 
 To set up ProtGraph make sure you have `pipenv` and `pyenv` installed. (via `pacman` `apt` and alike)
 
-
-First download this repository and then install needed dependencies with:
+First install needed dependencies with:
 > pipenv install  && pipenv install -d
 
-Afterwards execute the following to install the module ProtGraph:
+Afterwards execute the following to install the module ProtGraph inside the environment:
 > pipenv run pip install -e .
 
 If both commands finished succesfully, activate the environment via:
@@ -104,10 +99,13 @@ If both commands finished succesfully, activate the environment via:
 
 You should be able to run `protgraph` now. Via the flag `-e` the code from the projects directory is used, so you can edit the files directly and test the changes via your debugger of choice or via the command `protgraph`.
 
+Tests can be executed as follows: Make sure you are at the root folder of this project. Then execute `pytest .` to run the tests for ProtGraph.
 
-#### Testing
+#### Troubleshooting
 
-Make sure you are at the root folder of this project. Then execute `pytest .` to run the tests for ProtGraph.
+ProtGraph has many dependencies which are mostly due to the export functionalities. For the dependency `psycopg2`, it may be neccessary to install PostgreSQL on your operating system, so that the wheel can be built. It should be sufficient to install it as follows `sudo pacman -S postgres` (adapt this for `apt` and alike).
+
+If the command `protgraph` cannot be found, make sure that you have included the python executables folder in your environment variable `PATH`. (If pip was executed with the flag `--user`, then the binaries should be available in the folder: `~/.local/bin`)
 
 ## Usage
 
@@ -119,11 +117,11 @@ Let's use the provided example `e_coli.dat` located in `examples/e_coli.dat` (Or
 
 The graph generation can be executed via: `protgraph examples/e_coli.dat`. This will generate the graphs and the additional statistics file. You can inspect the statistics file after it has finished. This should only take a few seconds/minutes.
 
-A progressbar was not shown during execution which is due to `Biopython` not provide information of how many entries are available in a `.txt` or `.dat` file.Therefore this information needs to be provided via another parameter: `protgraph --num_of_entries 9434 examples/e_coli.dat` (you can also use `-n`).
+A progressbar was not shown during execution which is due to `Biopython` not providing information of how many entries are available in a `.txt` or `.dat` file.Therefore this information needs to be provided via another parameter: `protgraph --num_of_entries 9434 examples/e_coli.dat` (you can also use `-n`).
 
-To retrieve the number of entries beforehand, you could e.g. use `cat examples/e_coli.dat | grep "^//" | wc -l`. It is also possible to add multiple files. The number of entries for each file then need to be summed: `protgraph -n 18868 examples/e_coli.dat examples/e_coli.dat`
+To retrieve the number of entries beforehand, you could e.g. use `cat examples/e_coli.dat | grep "^//" | wc -l`. It is also possible to add multiple files into ProtGraph. The number of entries for each file then need to be summed: `protgraph -n 18868 examples/e_coli.dat examples/e_coli.dat`
 
-If to many (or to few) processes are executed, then it can be adjusted via the parameter `--num_of_processes` or `-np`. E.G. `protgraph --num_of_processes 3 --num_of_entries 9434 examples/e_coli.dat` will use 4 (`3` + 1 reading process) processes.
+If too many (or too few) processes are executed, then it can be adjusted via the parameter `--num_of_processes` or `-np`. E.G. `protgraph --num_of_processes 3 --num_of_entries 9434 examples/e_coli.dat` will use 4 (`3` + `1` reading) processes.
 
 To fully annotate the graphs with weights and to retrieve currently all available statistics, use the following: `protgraph -amwe -aawe -cnp -cnpm -cnph -n 9434 examples/e_coli.dat`
 
@@ -131,10 +129,10 @@ To fully annotate the graphs with weights and to retrieve currently all availabl
 
 Fasta export examples:
 
-Use Protgraph to get all possible peptides from isoforms and canonoical for `e_coli.dat` into a fasta file:
+Protgraph can be used to get all possible peptides from isoforms and canonoical for `e_coli.dat` into a fasta file:
 > protgraph -n 9434 -sv -ss -sm -epepfasta examples/e_coli.dat
 
-Instead of having only peptides, get all possible proteins with isoforms and canonoical for `e_coli.dat` into a fasta file:
+Instead of only containing peptides, ProtGraph can get all possible proteins with isoforms and canonoical for `e_coli.dat` into a fasta file:
 > protgraph -n 9434 -sv -ss -sm -d skip -epepfasta examples/e_coli.dat
 
 It could also be interesing to get a fasta file of proteins with all variants, isoforms, cleaved or not cleaved signal peptide/initiator methionine:
@@ -158,29 +156,25 @@ It is advisable to do a dry run with the flags `-cnp`, `-cnpm` or `cnph` (or all
 
 While executing ProtGraph, generated graphs are not saved. This is also true for peptides or proteins, which are represented by the graphs.
 
-This is the default behaviour of `protgraph`. It excludes the generated graphs/proteins/peptides, since those can explode in size and the disk space on machines may also be limited. This is illustrated in examples.
+This is the default behaviour of `protgraph`. It excludes the generated graphs/proteins/peptides, since those can explode in size and the disk space on machines may also be limited. This is illustrated in the above examples.
 
-However, those exporting functionalities can be used. Those differ in two categories: `-e*` for graph exports and `-epep` for peptide/protein exports. For the peptide/protein exports limitations can be set on the graph-traversal itself.
-
+However, those exporting functionalities can be used. Those differ in two categories: `-e*` for graph exports and `-epep*` for peptide/protein exports. For the peptide/protein exports limitations can be set on the graph-traversal itself.
 
 **NOTE:** Graphs can contain unmanagable amounts of peptides/proteins. Do a dry run WITHOUT the export functionality first and examine the statistics output. Each peptide/protein exporter has multiple parameters to further limit the number of results.
-Without a dry run it may happen that a protein like P04637 (P53 Human) with all possible peptides and variants is exported, which would take up all disk space.
-
+Without a dry run it may happen that a protein like P04637 (P53 Human) with all possible peptides and variants is exported, which will very likely take up all disk space.
 
 It is planned to add further export functionalities if needed.
-
 
 ### File Exports
 
 To export each protein graph into a file, simply set the flags `-edot`, `-egraphml` and/or `-egml`, which will create the corresponding dot, GraphML or GML files into a output folder. With the flag `-epickle` it is also possible to generate a binary pickle file of the graph (which can be used by other python programs with `igraph`).
-If processing many proteins (over 1 000 000) it is recommended to set the flag `-edirs` to save the graphs into multiple files, since the underlying filesystem may be overwhelmed with so many files in one folder.
+If processing many proteins (over 1 000 000) it is recommended to set the flag `-edirs` to save the graphs into multiple folders, since the underlying filesystem may be overwhelmed with too many files in one folder.
 
 Exporting to GraphML is recommended since this is the only export method able to serialize all properties in a file which may be set in a graph. However, keep in mind that this export needs the most disk space out of the other graph exporters.
 
 There is also the possibility to directly export graphs into a `fasta` file. This can be achieved via: `-epepfasta`.
 
 ### Database Exporters
-
 
 ProtGraph offers multiple database-/storage-exporters. It is possible to export graphs into PostgreSQL/MySQL/RedisGraph and Gremlin (experimental). For PostgreSQL as well as MySQL two tables (`nodes`, `edges`) are generated and corresponding entries for each graph are added.
 

--- a/protgraph/cli.py
+++ b/protgraph/cli.py
@@ -521,7 +521,7 @@ def add_gremlin_graph_export(group):
         "(tested on JanusGraph and Apache Gremlin Server). This exporter is not well implemented and may not work. "
         "This is due to difficulties implementing such an exporter in a global manner. "
         "To reduce the number of errors: Try to have a stable connection to the gremlin-server and also allocate "
-        "enough resource for it, so that it can process the queries quick enough."
+        "enough resources for it, so that it can process the queries quick enough."
     )
     group.add_argument(
         "--gremlin_url", type=str, default="ws://localhost:8182/gremlin",

--- a/protgraph/digestion.py
+++ b/protgraph/digestion.py
@@ -103,7 +103,13 @@ def _digest_via_full(graph):
     start_in.remove(__start_node__.index)
     start_in.remove(__end_node__.index)
     for i in graph.neighbors(__start_node__, mode="OUT"):
-        start_in.remove(i)
+        try:
+            start_in.remove(i)
+        except Exception:
+            print(
+                "WARNING: Graph has parallel edges, which may be due to the input file. "
+                "Please check if features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
+            )
 
     # Do the same for end to get all nodes which need OUT edges
     end_out = graph.vs.indices
@@ -111,7 +117,13 @@ def _digest_via_full(graph):
     end_out.remove(__start_node__.index)
     end_out.remove(__end_node__.index)
     for i in graph.neighbors(__end_node__, mode="IN"):
-        end_out.remove(i)
+        try:
+            end_out.remove(i)
+        except Exception:
+            print(
+                "WARNING: Graph has parallel edges, which may be due to the input file. "
+                "Please check if features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
+            )
 
     # Get all edges, which should be cleaved and mark them
     cleaved_edges = [

--- a/protgraph/digestion.py
+++ b/protgraph/digestion.py
@@ -108,7 +108,7 @@ def _digest_via_full(graph):
         except Exception:
             print(
                 "WARNING: Graph has parallel edges, which may be due to the input file. "
-                "Please check if features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
+                "Please check that features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
             )
 
     # Do the same for end to get all nodes which need OUT edges
@@ -122,7 +122,7 @@ def _digest_via_full(graph):
         except Exception:
             print(
                 "WARNING: Graph has parallel edges, which may be due to the input file. "
-                "Please check if features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
+                "Please check that features are not repeated! (Entry: {})".format(graph.vs[0]["accession"])
             )
 
     # Get all edges, which should be cleaved and mark them

--- a/protgraph/export/mysql.py
+++ b/protgraph/export/mysql.py
@@ -67,7 +67,7 @@ class MySQL(AExporter):
                 );""")
 
         except Exception as e:
-            print("Error creating nodes table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'nodes' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -97,7 +97,7 @@ class MySQL(AExporter):
                 );""".format("BIGINT" if kwargs["mass_dict_type"] is int else "DOUBLE"))
 
         except Exception as e:
-            print("Error creating edges table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'edges' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()

--- a/protgraph/export/peptides/pep_citus.py
+++ b/protgraph/export/peptides/pep_citus.py
@@ -91,7 +91,7 @@ class PepCitus(APeptideExporter):
                     accession VARCHAR(15) NOT NULL
                 );""")
         except Exception as e:
-            print("Error createing accessions table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'accessions' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -137,7 +137,7 @@ class PepCitus(APeptideExporter):
                 ))
             cur.execute("SELECT create_distributed_table(%s, %s);", ("peptides", "id", ))
         except Exception as e:
-            print("Error createing peptides table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -166,7 +166,7 @@ class PepCitus(APeptideExporter):
             # References to peptide and accession removed for performance reasons
             cur.execute("SELECT create_distributed_table(%s, %s);", ("peptides_meta", "peptides_id", ))
         except Exception as e:
-            print("Error createing peptides_meta table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides_meta' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()

--- a/protgraph/export/peptides/pep_fasta.py
+++ b/protgraph/export/peptides/pep_fasta.py
@@ -115,7 +115,7 @@ class PepFasta(APeptideExporter):
     def _get_variant_qualifier(self, feature):
         """ Get x -> y or missing """
         message = feature.qualifiers["note"]
-        message = message[:message.index("(")-1]
+        message = message[:message.index("(")-1] if "(" in message else message
 
         if feature.id is not None:
             message + ", " + feature.id

--- a/protgraph/export/peptides/pep_fasta.py
+++ b/protgraph/export/peptides/pep_fasta.py
@@ -68,7 +68,7 @@ class PepFasta(APeptideExporter):
                     "".join(
                         [
                             acc, "(", str(start_pos), ":", str(end_pos), ",",
-                            "mssclvg:", str(misses),
+                            "mssclvg:", str(misses), ",",
                             quali_entries,  ")"
                         ]
                     )

--- a/protgraph/export/peptides/pep_mysql.py
+++ b/protgraph/export/peptides/pep_mysql.py
@@ -101,7 +101,7 @@ class PepMySQL(APeptideExporter):
                     PRIMARY KEY(id)
                 );""")
         except Exception as e:
-            print("Error creating accessions table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'nodes' (accessions: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -147,7 +147,7 @@ class PepMySQL(APeptideExporter):
                     )
                 )
         except Exception as e:
-            print("Error creating peptides table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -175,7 +175,7 @@ class PepMySQL(APeptideExporter):
                 )
             )  # References to peptide and accession removed for performance reasons
         except Exception as e:
-            print("Error creating peptides_meta table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides_meta' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()

--- a/protgraph/export/peptides/pep_postgres.py
+++ b/protgraph/export/peptides/pep_postgres.py
@@ -91,7 +91,7 @@ class PepPostgres(APeptideExporter):
                     accession VARCHAR(15) NOT NULL
                 );""")
         except Exception as e:
-            print("Error createing accessions table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'nodes' (accessions: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -136,7 +136,7 @@ class PepPostgres(APeptideExporter):
                 "BIGINT" if kwargs["mass_dict_type"] is int else "DOUBLE PRECISION"
                 ))
         except Exception as e:
-            print("Error createing peptides table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -164,7 +164,7 @@ class PepPostgres(APeptideExporter):
             );""".format("BIT(452)" if self.postgres_no_duplicates else "BIGINT"))
             # References to peptide and accession removed for performance reasons
         except Exception as e:
-            print("Error createing peptides_meta table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'peptides_meta' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()

--- a/protgraph/export/postgres.py
+++ b/protgraph/export/postgres.py
@@ -67,7 +67,7 @@ class Postgres(AExporter):
                 );""")
 
         except Exception as e:
-            print("Error createing nodes table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'nodes' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()
@@ -96,7 +96,7 @@ class Postgres(AExporter):
                 );""".format("BIGINT" if kwargs["mass_dict_type"] is int else "DOUBLE PRECISION"))
 
         except Exception as e:
-            print("Error createing edges table. Continuing... (Reason: {})".format(str(e)))
+            print("Warning: Failed creating table 'edges' (Reason: {})".format(str(e)))
         finally:
             self.conn.commit()
             cur.close()

--- a/protgraph/ft_execution/variant.py
+++ b/protgraph/ft_execution/variant.py
@@ -1,3 +1,5 @@
+from protgraph.unexpected_exception import UnexpectedException
+
 def execute_variant(graph, variant_feature):
     """
     This function adds vertices and edges depending on the feature variant.
@@ -147,9 +149,14 @@ def _combine_vertices(list_a, list_b):
         if key not in out_d:
             out_d[key] = dict(inn=[a])
         else:
-            # TODO we cannot simply associate via accession!?!?
-            # TODO generate custom exception to report the occuring Error!
-            raise Exception("Exisiting Key would be overwritten.")
+            # We cannot simply associate via accession?
+            # Does this case ever happen !?!
+            raise UnexpectedException(
+                accession=None,
+                position=None,
+                message="Exisiting Key would be overwritten. Additional Info contains dict, lista and listb",
+                additional_info=str([out_d, list_a, list_b])
+            )
 
     # Sort the second list (outgoing, b)
     for b in list_b:

--- a/protgraph/ft_execution/variant.py
+++ b/protgraph/ft_execution/variant.py
@@ -1,5 +1,6 @@
 from protgraph.unexpected_exception import UnexpectedException
 
+
 def execute_variant(graph, variant_feature):
     """
     This function adds vertices and edges depending on the feature variant.

--- a/protgraph/protgraph.py
+++ b/protgraph/protgraph.py
@@ -27,9 +27,9 @@ def prot_graph(**kwargs):
         raise TypeError("missing argument 'files'")
 
     # Set up queues
-    entry_queue = Queue(1000)  # TODO limit? or not to limit?
-    statistics_queue = Queue()
-    common_out_file_queue = Queue()
+    entry_queue = Queue(10000)
+    statistics_queue = Queue(10000)
+    common_out_file_queue = Queue(10000)
 
     # Get the number of processes.
     number_of_procs = \

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='protgraph',
-    version='0.1.0',
+    version='0.1.1',
     author="Dominik Lux",
     description="ProtGraph, a graph generator for proteins.",
     long_description=long_description,

--- a/utilities/print_sum_miscleavages.py
+++ b/utilities/print_sum_miscleavages.py
@@ -28,7 +28,7 @@ def parse_args():
     # Statistics file
     parser.add_argument(
         "input_csv", type=_check_if_file_exists, nargs=1,
-        help="File containing the statistics output from ProtGraph (generated via '-cnph')"
+        help="File containing the statistics output from ProtGraph (generated via '-cnpm')"
     )
 
     # Number of entries in csv

--- a/utilities/print_sum_miscleavages.py
+++ b/utilities/print_sum_miscleavages.py
@@ -1,0 +1,92 @@
+import argparse
+import ast
+import csv
+import math
+import os
+import sys
+from operator import add
+
+import tqdm
+
+csv.field_size_limit(sys.maxsize)
+
+
+def _check_if_file_exists(s: str):
+    """ checks if a file exists. If not: raise Exception """
+    # TODO copied from prot_graph.py
+    if os.path.isfile(s):
+        return s
+    else:
+        raise Exception("File '{}' does not exists".format(s))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Graph-Generator for Proteins/Peptides and Exporter to various formats"
+    )
+
+    # Statistics file
+    parser.add_argument(
+        "input_csv", type=_check_if_file_exists, nargs=1,
+        help="File containing the statistics output from ProtGraph (generated via '-cnph')"
+    )
+
+    # Number of entries in csv
+    parser.add_argument(
+        "--num_entries", "-n", type=int, default=None,
+        help="Number of entries in csv. If provided, an estimate of needed time can be reported. Default None"
+    )
+
+    return parser.parse_args()
+
+
+def add_lists(list_a, list_b):
+    """ Appends 0 if list A or B is too short. Does the operation '+' to two lists (vectors, etc.) """
+    if len(list_a) > len(list_b):
+        # Swap elements if the other is larger
+        t = list_a
+        list_a = list_b
+        list_b = t
+    return list(map(
+        add,
+        list_a + [0]*(len(list_b) - len(list_a)),
+        list_b
+    ))
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Parameters
+    statistics_file = args.input_csv[0]
+    num_entries = args.num_entries
+
+    # Static parameter, always 11th entry in statistics file
+    mis_entry = 10
+
+    # Open al files and sort them accordingly
+    with open(statistics_file, "r") as in_file:
+        # Initialize CSV reader
+        csv_in = csv.reader(in_file)
+
+        # Skip Header
+        k = next(csv_in)
+
+        # Sum all entries
+        summation = []
+        for row in tqdm.tqdm(csv_in, unit="rows", total=num_entries):
+            in_list = ast.literal_eval(row[mis_entry])
+            summation = add_lists(summation, in_list)
+
+        # print results
+        idx_len = str(int(math.log10(len(summation)))+1)
+        entry_len = str(int(math.log10(max(summation)))+1)
+        print("Sum of each entry")
+        for idx, entry in enumerate(summation):
+            print(("{:>" + idx_len + "}:  {:>" + entry_len + "}").format(idx, entry))
+
+        print("\n\n\nCummulative Sum")
+        k = 0
+        for idx, entry in enumerate(summation):
+            k += entry
+            print(("{:>" + idx_len + "}:  {:>" + entry_len + "}").format(idx, k))


### PR DESCRIPTION
Some cases and errors may have not been covered by the first release. 

Here we gather and solve them in this PR:

Fixed errors:

- [x] Fasta Export has a missing `,` before the first FeatureTable entry in Header
- [x] Memory usage is high on exporting (maybe due to unlimited sized queues)
- [x] Fixes #32 The case of multiple edges was not considered.
- [x] Fixes #33 The case of variants without descriptions was not considered
- [x] Disabled MyPy from SuperLinter ( due to unhelpful output in the action console ) 