### PR TITLE
add multithreading queue size arg

### DIFF
--- a/protgraph/cli.py
+++ b/protgraph/cli.py
@@ -230,9 +230,8 @@ def add_graph_generation(group):
         "so that each mass can be converted into integers."
     )
     group.add_argument(
-        "--multithreading_queue_size", "-mtqs", type=int, default=300000,
-        help="Set the size of the queues for the multithreading. Sizes above 30000 have previously caused problems "
-        "on MacOS. Default is set to 300000."
+        "--queue_size", "-qs", type=int, default=30000,
+        help="Set the size of the queues, default is 30000"
     )
 
 

--- a/protgraph/cli.py
+++ b/protgraph/cli.py
@@ -229,6 +229,11 @@ def add_graph_generation(group):
         help="Set the factor for the masses inside the mass_dictionary. The default is set to 1 000 000 000, "
         "so that each mass can be converted into integers."
     )
+    group.add_argument(
+        "--multithreading_queue_size", "-mtqs", type=int, default=300000,
+        help="Set the size of the queues for the multithreading. Sizes above 30000 have previously caused problems "
+        "on MacOS. Default is set to 300000."
+    )
 
 
 def add_statistics(group):

--- a/protgraph/protgraph.py
+++ b/protgraph/protgraph.py
@@ -32,12 +32,12 @@ def prot_graph(**kwargs):
     if "files" not in kwargs or kwargs["files"] is None:
         raise TypeError("missing argument 'files'")
 
-    multithreading_queue_size = prot_graph_args["multithreading_queue_size"]
+    queue_size = prot_graph_args["queue_size"]
 
     # Set up queues
-    entry_queue = ctx.Queue(multithreading_queue_size)
-    statistics_queue = ctx.Queue(multithreading_queue_size)
-    common_out_file_queue = ctx.Queue(multithreading_queue_size)
+    entry_queue = ctx.Queue(queue_size)
+    statistics_queue = ctx.Queue(queue_size)
+    common_out_file_queue = ctx.Queue(queue_size)
 
     # Get the number of processes.
     number_of_procs = \

--- a/protgraph/protgraph.py
+++ b/protgraph/protgraph.py
@@ -32,10 +32,12 @@ def prot_graph(**kwargs):
     if "files" not in kwargs or kwargs["files"] is None:
         raise TypeError("missing argument 'files'")
 
+    multithreading_queue_size = prot_graph_args["multithreading_queue_size"]
+
     # Set up queues
-    entry_queue = ctx.Queue(300000)
-    statistics_queue = ctx.Queue(300000)
-    common_out_file_queue = ctx.Queue(300000)
+    entry_queue = ctx.Queue(multithreading_queue_size)
+    statistics_queue = ctx.Queue(multithreading_queue_size)
+    common_out_file_queue = ctx.Queue(multithreading_queue_size)
 
     # Get the number of processes.
     number_of_procs = \


### PR DESCRIPTION
Problem: On (my) MacOs, I get the an OSError (below) when trying to use ProtGraph. A solution for me is to change the Queue-Size to a maximum of about 32000.

As I suspect that more people might run into this problem I thought a very simple solution without breaking changes or changing the default behaviour could be to add an argument to the parser.

My suggestion is included within the following PR.

I'm happy to discuss this and would be very gratefull if something along these lines could be enabled because it would enable me to use ProtGraph for my Bachelor-Thesis.

Best
Anton


```
Traceback (most recent call last):
 File "/.../anaconda3/envs/protGraph/bin/protgraph", line 8, in <module>
   sys.exit(main())
            ^^^^^^
 File "/.../anaconda3/envs/protGraph/lib/python3.11/site-packages/protgraph/protgraph.py", line 18, in main
   prot_graph(**ARGS)
 File "/.../anaconda3/envs/protGraph/lib/python3.11/site-packages/protgraph/protgraph.py", line 36, in prot_graph
   entry_queue = ctx.Queue(300000)
                 ^^^^^^^^^^^^^^^^^
 File "/.../anaconda3/envs/protGraph/lib/python3.11/multiprocessing/context.py", line 103, in Queue
   return Queue(maxsize, ctx=self.get_context())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/.../anaconda3/envs/protGraph/lib/python3.11/multiprocessing/queues.py", line 49, in __init__
   self._sem = ctx.BoundedSemaphore(maxsize)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/.../anaconda3/envs/protGraph/lib/python3.11/multiprocessing/context.py", line 88, in BoundedSemaphore
   return BoundedSemaphore(value, ctx=self.get_context())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/.../anaconda3/envs/protGraph/lib/python3.11/multiprocessing/synchronize.py", line 145, in __init__
   SemLock.__init__(self, SEMAPHORE, value, value, ctx=ctx)
 File "/.../anaconda3/envs/protGraph/lib/python3.11/multiprocessing/synchronize.py", line 57, in __init__
   sl = self._semlock = _multiprocessing.SemLock(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 22] Invalid argument
```